### PR TITLE
Fix restart countdown timer

### DIFF
--- a/lib/game/main.js
+++ b/lib/game/main.js
@@ -125,7 +125,7 @@ ig.module(
 			this.preRender.height = ig.system.canvas.height;
 			this.preContext = this.preRender.getContext('2d');
 
-			this.restartCoutDown = new ig.Timer();
+                        this.restartCountdown = new ig.Timer();
 
 			this.overlayDelay = 2;
 			this._initLevel = true;
@@ -217,7 +217,7 @@ ig.module(
 			this.parent();
 			this.sortEntitiesDeferred();
 
-			if (this.restarting && this.restartCoutDown.delta() > 0) {
+                        if (this.restarting && this.restartCountdown.delta() > 0) {
 				this.restart();
 			} else {
 				if (!this.paused && this.toBeContinued) {
@@ -238,7 +238,7 @@ ig.module(
 		gameOver: function() {
 			if (!this.restarting) {
 				this.restarting = true;
-				this.restartCoutDown.set(RESTART_COUNTDOWN);
+                                this.restartCountdown.set(RESTART_COUNTDOWN);
 			}
 		},
 


### PR DESCRIPTION
## Summary
- correct the `restartCountdown` timer variable name

## Testing
- `../tools/bake.sh` *(fails: `php` not found)*
- `gulp build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401e9f85508323908534f61ad94e88